### PR TITLE
fix(unstructured-documents): optional collection param

### DIFF
--- a/martini/apps/documents/serializers.py
+++ b/martini/apps/documents/serializers.py
@@ -7,6 +7,9 @@ class UnstructuredDocumentSerializer(serializers.ModelSerializer):
     class Meta:
         model = UnstructuredDocument
         fields = ['id', 'name', 'description', 'file', 'task_id', 'collection']
+        extra_kwargs = {
+            'collection': {'required': False}
+        }
 
     def to_representation(self, instance):
         rep = super().to_representation(instance)


### PR DESCRIPTION
Ensure the `collection` parameter is optional when creating using the API.
The collection should be optional because it falls back to default if not provided.