### PR TITLE
feat(chats): enable querying llm using collection id instead of name

### DIFF
--- a/martini/apps/chats/views.py
+++ b/martini/apps/chats/views.py
@@ -4,6 +4,7 @@ from rest_framework.response import Response
 from langchain.chains.question_answering import load_qa_chain
 
 from apps.documents.vectorstore import get_vectorstore_for_chains
+from apps.documents.models import DocumentCollection
 from apps.chats.llm import get_embeddings_model, get_llm
 
 
@@ -14,11 +15,12 @@ class MessageViewSet(viewsets.ViewSet):
         This is the bread and butter of the "chat your documents" feature.
         '''
         query = request.data.get('query')
+        collection_id = request.data.get('collection_id')
         collection_name = request.data.get('collection_name')
 
-        if query is None or collection_name is None:
+        if query is None or (collection_id is None and collection_name is None):
             return Response(
-                {"error": "query and collection_name parameters are required."},
+                {"error": "query, and collection_id or collection_name parameters, are required."},
                 status=status.HTTP_400_BAD_REQUEST
             )
 
@@ -26,11 +28,18 @@ class MessageViewSet(viewsets.ViewSet):
         status_code = None
 
         try:
+            # If a collection id is provided, use that to get the collection name.
+            if collection_id:
+                collection_name = DocumentCollection.objects.get(id=collection_id).name
+                if not collection_name:
+                    raise Exception('DocumentCollection not found.')
+
             docsearch = get_vectorstore_for_chains(get_embeddings_model(), collection_name)
             llm = get_llm()
+            query = query.strip()
             chain = load_qa_chain(llm, chain_type='stuff')
             docs = docsearch.similarity_search(query)
-            answer = chain.run(input_documents=docs, question=query)
+            answer = chain.run(input_documents=docs, question=query).strip()
             payload = {
                 'query': query,
                 'answer': answer,


### PR DESCRIPTION
When querying the LLM on a document, a reference to the collection must be passed.
Enable using collection ID as well as collection name.